### PR TITLE
BUGFIX: Remove translation auto includes (there are no translations)

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,10 +1,5 @@
 Neos:
   Neos:
-    userInterface:
-      translation:
-        autoInclude:
-          'Flownative.Neos.CacheManagement': ['Modules']
-
     modules:
       administration:
         submodules:


### PR DESCRIPTION
Flownative.Cachemanagement does not have own translation files, yet they are included in the Settings.yaml.

See https://github.com/neos/neos-development-collection/issues/1886#issuecomment-364377936