### PR TITLE
FEATURE: Add translation, ui optimizations and command after flushing 

### DIFF
--- a/Classes/Controller/Module/Administration/CachesController.php
+++ b/Classes/Controller/Module/Administration/CachesController.php
@@ -14,6 +14,7 @@ namespace Flownative\Neos\CacheManagement\Controller\Module\Administration;
 use Neos\Error\Messages\Message;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cache\CacheManager;
+use Neos\Flow\Core\Booting\Scripts;
 use Neos\Neos\Controller\Module\AbstractModuleController;
 
 /**
@@ -41,6 +42,12 @@ class CachesController extends AbstractModuleController
     protected array $uiSettings;
 
     /**
+     * @Flow\InjectConfiguration(package="Neos.Flow")
+     * @var array
+     */
+    protected array $flowSettings;
+
+    /**
      * @return void
      * @throws \Neos\Cache\Exception\NoSuchCacheException
      */
@@ -61,12 +68,40 @@ class CachesController extends AbstractModuleController
      */
     public function flushAction(string $cacheIdentifier): void
     {
-        if(array_key_exists($cacheIdentifier, $this->getCacheConfiguration())) {
+        if (array_key_exists($cacheIdentifier, $this->getCacheConfiguration())) {
             $this->cacheManager->getCache($cacheIdentifier)->flush();
             $this->addFlashMessage('Successfully flushed the cache "%s".', 'Cache cleared', Message::SEVERITY_OK, [$cacheIdentifier], 1448033946);
-        }else{
+
+            if (array_key_exists('runAfter', $this->cacheConfiguration[$cacheIdentifier]) && $this->cacheConfiguration[$cacheIdentifier]['runAfter']) {
+                $runAfterConfig = $this->cacheConfiguration[$cacheIdentifier]['runAfter'];
+                $command = $runAfterConfig;
+                $asyncCommand = false;
+
+                if (is_array($runAfterConfig)) {
+                    if (array_key_exists('async', $runAfterConfig)) {
+                        $asyncCommand = $runAfterConfig['async'] === true;
+                    }
+
+                    if (!array_key_exists('command', $runAfterConfig)) {
+                        $this->addFlashMessage('Cache "%s" is configured to run a command after flushing, but no command is configured.', 'No command configured', Message::SEVERITY_ERROR, [$cacheIdentifier], 1741167344);
+                        $this->redirect('index');
+                    }
+
+                    $command = $runAfterConfig['command'];
+                }
+
+                if ($asyncCommand) {
+                    Scripts::executeCommandAsync($command, $this->flowSettings);
+                    $this->addFlashMessage('Running command "%s" asynchronously.', 'Command executed', Message::SEVERITY_NOTICE, [$command], 1741167356);
+                } else {
+                    Scripts::executeCommand($command, $this->flowSettings);
+                    $this->addFlashMessage('Running command "%s".', 'Command executed', Message::SEVERITY_NOTICE, [$command], 1741167361);
+                }
+            }
+        } else {
             $this->addFlashMessage('Cache "%s" is not configured for flushing.', 'Not configured', Message::SEVERITY_ERROR, [$cacheIdentifier], 1550221927);
         }
+
         $this->redirect('index');
     }
 

--- a/Classes/Controller/Module/Administration/CachesController.php
+++ b/Classes/Controller/Module/Administration/CachesController.php
@@ -35,6 +35,12 @@ class CachesController extends AbstractModuleController
     protected $cacheConfiguration;
 
     /**
+     * @Flow\InjectConfiguration(path="ui")
+     * @var array
+     */
+    protected array $uiSettings;
+
+    /**
      * @return void
      * @throws \Neos\Cache\Exception\NoSuchCacheException
      */
@@ -44,6 +50,7 @@ class CachesController extends AbstractModuleController
             $this->cacheConfiguration[$cacheIdentifier]['backendType'] = get_class($this->cacheManager->getCache($cacheIdentifier)->getBackend());
         }
         $this->view->assign('caches', $this->cacheConfiguration);
+        $this->view->assign('uiSettings', $this->uiSettings);
     }
 
     /**

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -14,6 +14,7 @@ Flownative:
     CacheManagement:
       ui:
         showCacheHint: true
+        hideCachesWithoutLabel: false
       caches:
         Neos_Fusion_Content:
           label: 'Neos Content'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -15,7 +15,10 @@ Flownative:
       caches:
         Neos_Fusion_Content:
           label: 'Neos Content'
+          description: 'Caches the rendering of Neos content elements.'
         Flow_Mvc_Routing_Route:
           label: 'Routes (Matching)'
+          description: 'Caches the matching of routes to controllers and actions.'
         Flow_Mvc_Routing_Resolve:
           label: 'Routes (Resolving)'
+          description: 'Caches the resolving of routes to URIs.'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -14,6 +14,7 @@ Flownative:
     CacheManagement:
       ui:
         showCacheHint: true
+        showBackendClass: true
         hideCachesWithoutLabel: false
       caches:
         Neos_Fusion_Content:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -12,6 +12,8 @@ Neos:
 Flownative:
   Neos:
     CacheManagement:
+      ui:
+        showCacheHint: true
       caches:
         Neos_Fusion_Content:
           label: 'Neos Content'

--- a/README.md
+++ b/README.md
@@ -39,3 +39,26 @@ Flownative:
       ui:
         showCacheHint: false
 ```
+
+### Hide a cache configuration
+
+You can hide all caches which do not have a label set by using the following configuration in your `Settings.yaml`:
+
+```yaml
+Flownative:
+  Neos:
+    CacheManagement:
+      ui:
+        hideCachesWithoutLabel: true
+```
+
+or you can hide a specific cache configuration by using the following configuration in your `Settings.yaml`:
+
+```yaml
+Flownative:
+  Neos:
+    CacheManagement:
+      caches:
+        Neos_Fusion_Content:
+          hidden: true
+```

--- a/README.md
+++ b/README.md
@@ -74,3 +74,31 @@ Flownative:
       ui:
         showBackendClass: false
 ```
+
+### Run a command after flushing a cache
+
+If you want to run a flow command after flushing a cache, you can use the following configuration in your `Settings.yaml`:
+
+```yaml
+Flownative:
+  Neos:
+    CacheManagement:
+      caches:
+        Neos_Fusion_Content:
+          runAfter: 'foo:bar --baz'
+```
+
+#### Run the command asynchronously
+
+To run the flow command asynchronously:
+
+```yaml
+Flownative:
+  Neos:
+    CacheManagement:
+      caches:
+        Neos_Fusion_Content:
+          runAfter:
+            command: 'foo:bar --baz'
+            async: true
+```

--- a/README.md
+++ b/README.md
@@ -62,3 +62,15 @@ Flownative:
         Neos_Fusion_Content:
           hidden: true
 ```
+
+### Hide the backend class
+
+To hide the backend class set the following configuration in your `Settings.yaml`:
+
+```yaml
+Flownative:
+  Neos:
+    CacheManagement:
+      ui:
+        showBackendClass: false
+```

--- a/README.md
+++ b/README.md
@@ -11,3 +11,19 @@ This [Neos](https://www.neos.io) backend module provides cache management functi
 # Installation
 
 Simply install this package via Composer. The package key is `flownative/neos-cachemanagement`.
+
+## Configuration
+
+### Add labels to a cache configuration
+
+To add a label and a description to a cache configuration, you can use the following configuration in your `Settings.yaml`:
+
+```yaml
+Flownative:
+  Neos:
+    CacheManagement:
+      caches:
+        Neos_Fusion_Content:
+          label: 'Neos Content'
+          description: 'Caches the rendering of Neos content elements.'
+```

--- a/README.md
+++ b/README.md
@@ -27,3 +27,15 @@ Flownative:
           label: 'Neos Content'
           description: 'Caches the rendering of Neos content elements.'
 ```
+
+### Hide Cache-Hint
+
+To hide the cache hint set the following configuration in your `Settings.yaml`:
+
+```yaml
+Flownative:
+  Neos:
+    CacheManagement:
+      ui:
+        showCacheHint: false
+```

--- a/Resources/Private/Templates/Module/Administration/Caches/Index.html
+++ b/Resources/Private/Templates/Module/Administration/Caches/Index.html
@@ -10,6 +10,9 @@
                     {f:translate(id:'table.name', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}
                 </th>
                 <th>
+                    {f:translate(id:'table.backend', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}
+                </th>
+                <th>
                     {f:translate(id:'table.description', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}
                 </th>
                 <th>&nbsp;</th>
@@ -19,6 +22,7 @@
                 <tr>
                     <td title="{cacheIdentifier}">{cache.label}</td>
                     <td>{cache.backendType}</td>
+                    <td>{cache.description}</td>
                     <td class="neos-action">
                         <div class="neos-pull-right">
                             <f:link.action action="flush" arguments="{cacheIdentifier: cacheIdentifier}" class="neos-button neos-button-primary" title="{f:translate(id:'option.flush.title', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}">

--- a/Resources/Private/Templates/Module/Administration/Caches/Index.html
+++ b/Resources/Private/Templates/Module/Administration/Caches/Index.html
@@ -9,9 +9,11 @@
                 <th>
                     {f:translate(id:'table.name', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}
                 </th>
-                <th>
-                    {f:translate(id:'table.backend', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}
-                </th>
+                <f:if condition="{uiSettings.showBackendClass}">
+                    <th>
+                        {f:translate(id:'table.backend', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}
+                    </th>
+                </f:if>
                 <th>
                     {f:translate(id:'table.description', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}
                 </th>
@@ -21,7 +23,9 @@
             <f:for each="{caches}" key="cacheIdentifier" as="cache">
                 <tr>
                     <td title="{cacheIdentifier}">{cache.label}</td>
-                    <td>{cache.backendType}</td>
+                    <f:if condition="{uiSettings.showBackendClass}">
+                        <td>{cache.backendType}</td>
+                    </f:if>
                     <td>{cache.description}</td>
                     <td class="neos-action">
                         <div class="neos-pull-right">

--- a/Resources/Private/Templates/Module/Administration/Caches/Index.html
+++ b/Resources/Private/Templates/Module/Administration/Caches/Index.html
@@ -33,8 +33,10 @@
                 </tr>
             </f:for>
         </table>
-        <p class="neos-help-inline">
-            <i class="icon-info"></i> {f:translate(id:'cacheHint', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}
-        </p>
+        <f:if condition="{uiSettings.showCacheHint}">
+            <p class="neos-help-inline">
+                <i class="icon-info"></i> {f:translate(id:'cacheHint', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}
+            </p>
+        </f:if>
     </div>
 </f:section>

--- a/Resources/Private/Templates/Module/Administration/Caches/Index.html
+++ b/Resources/Private/Templates/Module/Administration/Caches/Index.html
@@ -6,8 +6,12 @@
         <table class="neos-table">
             <thead>
             <tr>
-                <th>Name</th>
-                <th>Backend</th>
+                <th>
+                    {f:translate(id:'table.name', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}
+                </th>
+                <th>
+                    {f:translate(id:'table.description', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}
+                </th>
                 <th>&nbsp;</th>
             </tr>
             </thead>
@@ -17,14 +21,16 @@
                     <td>{cache.backendType}</td>
                     <td class="neos-action">
                         <div class="neos-pull-right">
-                            <f:link.action action="flush" arguments="{cacheIdentifier: cacheIdentifier}" class="neos-button neos-button-primary" title="Flush this cache">
-                                <i class="fas fa-sync icon-white"></i> Flush
+                            <f:link.action action="flush" arguments="{cacheIdentifier: cacheIdentifier}" class="neos-button neos-button-primary" title="{f:translate(id:'option.flush.title', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}">
+                                <i class="fas fa-sync icon-white"></i> {f:translate(id:'option.flush', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}
                             </f:link.action>
                         </div>
                     </td>
                 </tr>
             </f:for>
         </table>
-        <p class="neos-help-inline"><i class="icon-info"></i> Please note that having to flush the content caches manually usually is a sign of improper configuration. <a href="http://neos.readthedocs.org/en/stable/CreatingASite/ContentCache.html">More about this</a></p>
+        <p class="neos-help-inline">
+            <i class="icon-info"></i> {f:translate(id:'cacheHint', source:'Main', package:'Flownative.Neos.CacheManagement') -> f:format.raw()}
+        </p>
     </div>
 </f:section>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="" product-name="Flownative.Neos.CacheManagement" source-language="en" datatype="plaintext" target-language="de">
+        <body>
+            <trans-unit id="table.name" xml:space="preserve" approved="yes">
+                <source>Name</source>
+                <target xml:lang="de">Name</target>
+            </trans-unit>
+            <trans-unit id="table.backend" xml:space="preserve" approved="yes">
+                <source>Backend</source>
+                <target xml:lang="de">Backend</target>
+            </trans-unit>
+            <trans-unit id="option.flush" xml:space="preserve" approved="yes">
+                <source>Flush</source>
+                <target xml:lang="de">Leeren</target>
+            </trans-unit>
+            <trans-unit id="option.flush.title" xml:space="preserve" approved="yes">
+                <source>Flush this cache</source>
+                <target xml:lang="de">Diesen Cache leeren</target>
+            </trans-unit>
+            <trans-unit id="cacheHint" xml:space="preserve" approved="yes">
+                <source><![CDATA[Please note that having to flush the content caches manually usually is a sign of improper configuration. <a href="https://docs.neos.io/guide/rendering/caching">More about this</a>]]></source>
+                <target xml:lang="de"><![CDATA[Bitte beachten Sie, dass das manuelle Leeren des Inhaltscaches normalerweise ein Zeichen für eine falsche Konfiguration ist. <a href="https://docs.neos.io/guide/rendering/caching">Mehr erfahren</a>]]></target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -10,6 +10,10 @@
                 <source>Backend</source>
                 <target xml:lang="de">Backend</target>
             </trans-unit>
+            <trans-unit id="table.description" xml:space="preserve" approved="yes">
+                <source>Description</source>
+                <target xml:lang="de">Beschreibung</target>
+            </trans-unit>
             <trans-unit id="option.flush" xml:space="preserve" approved="yes">
                 <source>Flush</source>
                 <target xml:lang="de">Leeren</target>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="" product-name="Flownative.Neos.CacheManagement" source-language="en" datatype="plaintext">
+        <body>
+            <trans-unit id="table.name" xml:space="preserve" approved="yes">
+                <source>Name</source>
+            </trans-unit>
+            <trans-unit id="table.backend" xml:space="preserve" approved="yes">
+                <source>Backend</source>
+            </trans-unit>
+            <trans-unit id="option.flush" xml:space="preserve" approved="yes">
+                <source>Flush</source>
+            </trans-unit>
+            <trans-unit id="option.flush.title" xml:space="preserve" approved="yes">
+                <source>Flush this cache</source>
+            </trans-unit>
+            <trans-unit id="cacheHint" xml:space="preserve" approved="yes">
+                <source><![CDATA[Please note that having to flush the content caches manually usually is a sign of improper configuration. <a href="https://docs.neos.io/guide/rendering/caching">More about this</a>]]></source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -8,6 +8,9 @@
             <trans-unit id="table.backend" xml:space="preserve" approved="yes">
                 <source>Backend</source>
             </trans-unit>
+            <trans-unit id="table.description" xml:space="preserve" approved="yes">
+                <source>Description</source>
+            </trans-unit>
             <trans-unit id="option.flush" xml:space="preserve" approved="yes">
                 <source>Flush</source>
             </trans-unit>


### PR DESCRIPTION
### [feat: add german translation](https://github.com/flownative/neos-cachemanagement/commit/c4c2ce17068067f247682a77f0158382eb1cca64) 

add german translation


### [feat: show description in list](https://github.com/flownative/neos-cachemanagement/commit/c140b975bace7688cfaa2b4229a8fb789297523c) 

add an option to set the description of a cache configuration


### [feat: hide the cache config hint](https://github.com/flownative/neos-cachemanagement/commit/d86525106f95a2b9021eba438e206689b58ed5fb) 

add an option to hide the hint


### [feat: hide empty configurations](https://github.com/flownative/neos-cachemanagement/commit/5f3170275c5bb960c9fef345d3ae1d225be9250d) 

add an option to ignore empty configurations

Resolves: #8


### [feat: add option to hide backend class](https://github.com/flownative/neos-cachemanagement/commit/c4ee40ee7b1ab52baad84f372844e9feb6db441a) 

add an option to hide the backend class



### [feat: add an option to run a command after flushing](https://github.com/flownative/neos-cachemanagement/commit/d468b6718cca22f3f794a21ec00f3de0ccfcb50e) 

- Adds an option to run a flow comma after the cache was flushed
- The command can runned asynchronously

Resolves: #9